### PR TITLE
small grammar for header Update definitions.md

### DIFF
--- a/definitions.md
+++ b/definitions.md
@@ -28,7 +28,7 @@ fn sum(a: u32, b: u32) -> u32 {
 }
 ```
 
-## 10.3 External Function
+## 10.3 External Functions
 
 ### 10.3.1 Description
 


### PR DESCRIPTION
Header was originally "External Function", the following sentence then uses "External Functions" instead. Should both be plural?